### PR TITLE
fix: joining of absolute paths in FILES:${PN}

### DIFF
--- a/classes/bitbake-variable-substitution-helpers.bbclass
+++ b/classes/bitbake-variable-substitution-helpers.bbclass
@@ -10,7 +10,7 @@ def bitbake_variables_search_and_sub_all_FILES_PN(d):
 
   if files:
     for file in files.split():
-      bitbake_variables_search_and_sub(os.path.join(deploy_dir, file), delim, d)
+      bitbake_variables_search_and_sub(os.path.join(deploy_dir, *file.split(os.sep)), delim, d)
 
   return "true"
 


### PR DESCRIPTION
`FILES:${PN}` contains absolute paths (starting with `'/'`).
According to https://docs.python.org/3/library/os.path.html#os.path.join: 
```
If a segment is an absolute path ..., then all previous segments are ignored and joining continues from the absolute path segment
```
As a result of this behavior, `bitbake_variables_search_and_sub_all_FILES_PN` is doing search and sub in those absolute paths (like `/usr/bin`) and not in paths under `deploy_dir`.

With some debug logs it looks like this (on current `master`):
```
WARNING: wapi-0.1-r0 do_install: deploy_dir: /build/tmp/work/cortexa76-poky-linux/wapi/0.1/image
WARNING: wapi-0.1-r0 do_install: file: /usr/bin/*
WARNING: wapi-0.1-r0 do_install: joined: /usr/bin/*
```

With this fix:
```
WARNING: wapi-0.1-r0 do_install: deploy_dir: /build/tmp/work/cortexa76-poky-linux/wapi/0.1/image
WARNING: wapi-0.1-r0 do_install: file: /usr/bin/*
WARNING: wapi-0.1-r0 do_install: joined: /build/tmp/work/cortexa76-poky-linux/wapi/0.1/image/usr/bin/*
```